### PR TITLE
Check for self.root first, because os.path.join doesn't handle None-type very well.

### DIFF
--- a/src/mrs/developer/distributions.py
+++ b/src/mrs/developer/distributions.py
@@ -156,11 +156,11 @@ class List(Cmd):
     def __call__(self, channels=None, pargs=None):
         """So far we just list all distributions used by the current env
         """
-        if not os.path.isdir(os.path.join(self.root, 'eggs-mrsd')):
-            os.mkdir(os.path.join(self.root, 'eggs-mrsd'))
         if not self.root:
             logger.error("Not rooted, run 'mrsd init'.")
             return
+        if not os.path.isdir(os.path.join(self.root, 'eggs-mrsd')):
+            os.mkdir(os.path.join(self.root, 'eggs-mrsd'))
         if channels is None:
             if pargs is not None:
                 channels = pargs.channel


### PR DESCRIPTION
If you install mrs.developer and runs msrd list, you'll get the trace below.  os.path.join doesn't check for None type, and self.root is None, so it blows up in you face.
# ./bin/mrsd list

Traceback (most recent call last):
  File "./bin/mrsd", line 362, in <module>
    mrs.developer.console_script.mrsd()
  File "/Users/roel/.buildout/eggs/mrs.developer-0-py2.6.egg/mrs/developer/console_script.py", line 91, in **call**
    output = pargs.cmd(pargs=pargs)
  File "/Users/roel/.buildout/eggs/mrs.developer-0-py2.6.egg/mrs/developer/distributions.py", line 159, in **call**
    if not os.path.isdir(os.path.join(self.root, 'eggs-mrsd')):
  File "/Users/roel/workspace/npo.buildout/trunk/../bin/../lib/python2.6/posixpath.py", line 67, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'NoneType' object has no attribute 'endswith'
